### PR TITLE
update mask for ethernet.slot byte

### DIFF
--- a/apps/date65.c
+++ b/apps/date65.c
@@ -89,7 +89,7 @@ int main(void)
   {
     read(file, &eth_init, 1);
     close(file);
-    eth_init &= ~'0';
+    eth_init &= 0x07;
   }
   printf("- %u\n", eth_init);
 #endif

--- a/apps/hfs65.c
+++ b/apps/hfs65.c
@@ -309,7 +309,7 @@ int main(void)
     {
       read(file, &eth_init, 1);
       close(file);
-      eth_init &= ~'0';
+      eth_init &= 0x07;
     }
     printf("- %u", eth_init);
   }

--- a/apps/tweet65.c
+++ b/apps/tweet65.c
@@ -152,7 +152,7 @@ int main(void)
     {
       read(file, &eth_init, 1);
       close(file);
-      eth_init &= ~'0';
+      eth_init &= 0x07;
     }
     printf("- %u\n", eth_init);
   }

--- a/apps/wget65.c
+++ b/apps/wget65.c
@@ -469,7 +469,7 @@ int main(int, char *argv[])
     {
       read(file, &eth_init, 1);
       close(file);
-      eth_init &= ~'0';
+      eth_init &= 0x07;
     }
   }
 


### PR DESCRIPTION
When the ethernet.slot byte is in high ascii,  `& ~'0'` leaves bit 7 on. This results in a cosmetic issue printing the slot number (eg 132 vs 4)